### PR TITLE
Update to use new docker login command from aws

### DIFF
--- a/scripts/push_image_to_ecr.sh
+++ b/scripts/push_image_to_ecr.sh
@@ -113,13 +113,9 @@ tags=("$CIRCLE_SHA1" "$@")
 
 printf '%s\n' "${tags[@]}" | grep -q '^--' && error_usage "It looks like you're passing flags instead of tags"
 
-info "Fetching ECR login command"
-if ! command=$(aws ecr get-login --no-include-email --region "$region"); then
-    error "Problem executing 'aws ecr get-login command"
-fi
-
 info "Logging in to repo"
-$command || error "Problem logging in to repo"
+aws ecr get-login-password --region "$region" | docker login --username AWS --password-stdin "$repo_url" \
+    || error "Problem logging in to repo"
 
 for tag in "${tags[@]}"; do
     tag_and_push "$local_image:$CIRCLE_SHA1" "$repo_url:$tag"


### PR DESCRIPTION
get-login is deprecated: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
use get-login-password: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/get-login-password.html
instead