### PR TITLE
Bump CircleCI setup_remote_docker and add Authentication using org-global context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,19 @@
----
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_context: &global_context
+  context:
+    - org-global
+global_remote_docker: &global_remote_docker
+  version: 19.03.13
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 
 defaults: &defaults
   working_directory: /circleci
   docker:
     - image: docker:17.06.0-ce-git
+      <<: *global_dockerhub_auth
 
 version: 2
 


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

